### PR TITLE
取消在请求KIS接口前自动尝试刷新token

### DIFF
--- a/app/sdk/kis/api.ts
+++ b/app/sdk/kis/api.ts
@@ -73,8 +73,6 @@ class KingdeeSDK {
 
   private async request<T>(config: AxiosRequestConfig): Promise<AxiosResponse<T>> {
     try {
-      await this.refreshTokensIfNecessary();
-
       return await this.axiosInstance.request<T>(config);
     } catch (error) {
       if (axios.isAxiosError(error)) {


### PR DESCRIPTION
因为刷新token的结果没有持久化，如果在下次刷新token的定时任务执行之前停止服务，有可能因为数据库中的kis token不是最新状态，导致后续接口请求失败。